### PR TITLE
chore: update package, bump version

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,8 +3,6 @@ name: Build & Publish
 on:
   push:
     branches: [ master ]
-  pull_request:
-    branches: [ master ]
 
 jobs:
   build:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "idcac-playwright",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "idcac-playwright",
-      "version": "0.1.2",
+      "version": "0.1.3",
       "license": "ISC",
       "devDependencies": {
         "@babel/generator": "^7.21.9",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "idcac-playwright",
-  "version": "0.1.2",
+  "version": "0.1.3",
   "description": "I Don't Care About Cookies for Playwright/Puppeteer",
   "main": "index.js",
   "licenses": [


### PR DESCRIPTION
The updates (building this package from the latest IDCAC version from the Firefox repository) happen automatically with every push to `master`. See [`build.yml` GitHub action](https://github.com/apify/idcac/blob/master/.github/workflows/build.yml) for more details.

Closes #2 